### PR TITLE
changed the dlib component to only use the value for MIN_OBJECT_DETEC…

### DIFF
--- a/cpp/DlibFaceDetection/DlibFaceDetection.cpp
+++ b/cpp/DlibFaceDetection/DlibFaceDetection.cpp
@@ -150,7 +150,7 @@ void DlibFaceDetection::SetDefaultParameters() {
 
     //the amount of frame locations required
     //to save a track
-    min_object_detections_count = 3;
+    min_track_length = 3;
 
     //the minimum amount of similary required
     //by a detection to be matched with an
@@ -197,8 +197,8 @@ void DlibFaceDetection::SetReadConfigParameters() {
         max_intersection_overlap_pct = parameters["MAX_INTERSECTION_OVERLAP_AREA_PCT"].toFloat();
     }
 
-    if(parameters.contains("MIN_OBJECT_DETECTIONS_COUNT")) {
-        min_object_detections_count = parameters["MIN_OBJECT_DETECTIONS_COUNT"].toInt();
+    if(parameters.contains("MIN_TRACK_LENGTH")) {
+        min_track_length = parameters["MIN_TRACK_LENGTH"].toInt();
     }
 
     if(parameters.contains("MIN_TRACK_OBJECT_SIMILARITY_VALUE")) {
@@ -321,9 +321,9 @@ void DlibFaceDetection::CloseAnyOpenTracks() {
         for(auto &current_track : current_tracks) {
 
             //should never happen - but ignoring the track if stop frame already modified or
-            //there are less than MIN_OBJECT_DETECTIONS_COUNT frame locations
+            //there are less than MIN_TRACK_LENGTH frame locations
             if (current_track.mpf_video_track.stop_frame != -1
-                || current_track.mpf_video_track.frame_locations.size() < min_object_detections_count) {
+                || current_track.mpf_video_track.frame_locations.size() < min_track_length) {
                 continue;
             }
 
@@ -456,7 +456,7 @@ void DlibFaceDetection::UpdateTracks(const dlib::cv_image<dlib::uint8> &next_fra
         } else {
             //stop the track, save if meets requirements, and delete from current tracks
 
-            if(current_track->mpf_video_track.frame_locations.size() > min_object_detections_count) {
+            if(current_track->mpf_video_track.frame_locations.size() > min_track_length) {
                 //since the frame interval can be adjusted it makes sense to grab the index from the last frame location
                 current_track->mpf_video_track.stop_frame = current_track->mpf_video_track.frame_locations.rbegin()->first;
                 saved_tracks.push_back(*current_track);

--- a/cpp/DlibFaceDetection/DlibFaceDetection.cpp
+++ b/cpp/DlibFaceDetection/DlibFaceDetection.cpp
@@ -234,9 +234,6 @@ void DlibFaceDetection::GetPropertySettings(const map <string, string> &algorith
         else if (property == "MAX_INTERSECTION_OVERLAP_AREA_PCT") { //FLOAT
             max_intersection_overlap_pct = atof(str_value.c_str());
         }
-        else if (property == "MIN_OBJECT_DETECTIONS_COUNT") { //INT
-            min_object_detections_count = atoi(str_value.c_str());
-        }
         else if (property == "MIN_TRACK_OBJECT_SIMILARITY_VALUE") { //FLOAT
             min_track_object_similarity_value = atof(str_value.c_str());
         }

--- a/cpp/DlibFaceDetection/DlibFaceDetection.h
+++ b/cpp/DlibFaceDetection/DlibFaceDetection.h
@@ -89,7 +89,7 @@ private:
 
     double min_detection_confidence;
     float max_intersection_overlap_pct;
-    int min_object_detections_count;
+    int min_track_length;
     float min_track_object_similarity_value;
     double min_update_correlation;
 

--- a/cpp/DlibFaceDetection/plugin-files/config/mpfDlibFaceDetection.ini
+++ b/cpp/DlibFaceDetection/plugin-files/config/mpfDlibFaceDetection.ini
@@ -33,9 +33,6 @@ VERBOSE: 0
 #IMSHOW_ON should only be set to 1 when DEBUGGING
 IMSHOW_ON: 0
 
-#ActiveMQ polling interval in seconds
-POLLING_INTERVAL: 1
-
 #minimum x and y pixel size passed to the face detector 
 #MIN_FACE_SIZE has been removed the parameter is not currently being used - let users know that it is 40 x 40 pixels - maybe put a note in the release notes
 #dlib detects images around 80 pixels in size, changing to 40 because assuming a default pyramid up
@@ -47,7 +44,7 @@ MIN_DETECTION_CONFIDENCE: 0.1
 MAX_INTERSECTION_OVERLAP_AREA_PCT: 0.2 
 
 #(int) - the minumum amount of frame locations required to save a track
-MIN_OBJECT_DETECTIONS_COUNT: 3
+MIN_TRACK_LENGTH: 3
 
 #(float) - the minimum amount of similary required by a new detection to be matched with an existing track
 MIN_TRACK_OBJECT_SIMILARITY_VALUE: 0.6

--- a/cpp/DlibFaceDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/DlibFaceDetection/plugin-files/descriptor/descriptor.json
@@ -64,12 +64,6 @@
           "defaultValue": "0.2"
         },
         {
-          "name": "MIN_OBJECT_DETECTIONS_COUNT",
-          "description": "The minumum amount of frame locations required to save a track.",
-          "type": "INT",
-          "defaultValue": "3"
-        },
-        {
           "name": "MIN_TRACK_OBJECT_SIMILARITY_VALUE",
           "description": "The minimum amount of similarity required by a detection to be matched with an existing track.",
           "type": "FLOAT",


### PR DESCRIPTION
…TIONS_COUNT from its .ini file, and no longer look for it in the job properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-components/4)
<!-- Reviewable:end -->
