### PR TITLE
Allow the user to specify a region of interest for cropping as a percentage of the frame dimensions

### DIFF
--- a/cpp/CaffeDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/CaffeDetection/plugin-files/descriptor/descriptor.json
@@ -110,25 +110,25 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },

--- a/cpp/CaffeDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/CaffeDetection/plugin-files/descriptor/descriptor.json
@@ -110,26 +110,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/cpp/DarknetDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/DarknetDetection/plugin-files/descriptor/descriptor.json
@@ -111,26 +111,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/cpp/DarknetDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/DarknetDetection/plugin-files/descriptor/descriptor.json
@@ -111,25 +111,25 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },

--- a/cpp/DlibFaceDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/DlibFaceDetection/plugin-files/descriptor/descriptor.json
@@ -110,25 +110,25 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },

--- a/cpp/DlibFaceDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/DlibFaceDetection/plugin-files/descriptor/descriptor.json
@@ -110,26 +110,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/cpp/OalprLicensePlateTextDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/OalprLicensePlateTextDetection/plugin-files/descriptor/descriptor.json
@@ -111,25 +111,25 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
           "type": "INT",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
           "type": "INT",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
           "type": "INT",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
           "type": "INT",
           "defaultValue": "-1"
         },

--- a/cpp/OcvFaceDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/OcvFaceDetection/plugin-files/descriptor/descriptor.json
@@ -122,25 +122,25 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },

--- a/cpp/OcvFaceDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/OcvFaceDetection/plugin-files/descriptor/descriptor.json
@@ -122,26 +122,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/cpp/SceneChangeDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/SceneChangeDetection/plugin-files/descriptor/descriptor.json
@@ -78,25 +78,25 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },

--- a/cpp/SceneChangeDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/SceneChangeDetection/plugin-files/descriptor/descriptor.json
@@ -78,26 +78,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/cpp/TesseractOCRTextDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/TesseractOCRTextDetection/plugin-files/descriptor/descriptor.json
@@ -48,26 +48,26 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If negative, 0 will be used.",
-          "type": "INT",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If negative, bottom right X of input media will be used.",
-          "type": "INT",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If negative, bottom right Y of input media. will be used.",
-          "type": "INT",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "type": "STRING",
           "defaultValue": "-1"
         },
         {

--- a/cpp/TesseractOCRTextDetection/plugin-files/descriptor/descriptor.json
+++ b/cpp/TesseractOCRTextDetection/plugin-files/descriptor/descriptor.json
@@ -48,25 +48,25 @@
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_X_DETECTION",
-          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
+          "description": "X coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left X position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_TOP_LEFT_Y_DETECTION",
-          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
+          "description": "Y coordinate for top left corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If negative, the top left Y position will be set to 0.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_X_DETECTION",
-          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right X position will be set to the width of the frame.",
+          "description": "X coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the width of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right X position will be set to the width of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },
         {
           "name": "SEARCH_REGION_BOTTOM_RIGHT_Y_DETECTION",
-          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame. It's value must be between 0 and 100, inclusive. Otherwise, it will be interpreted as a pixel position. If negative, the bottom right Y position will be set to the height of the frame.",
+          "description": "Y coordinate for bottom right corner of cropped frame. If this string contains the % sign, then its numeric value will be interpreted as a percentage of the height of the frame, and its value will be capped between 0% and 100%, inclusive. If this string does not contain the % sign, then it will be interpreted as a pixel position. If zero or negative, the bottom right Y position will be set to the height of the frame.",
           "type": "STRING",
           "defaultValue": "-1"
         },


### PR DESCRIPTION
Modified the description of the cropping coordinates in each of the component descriptor files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-components/94)
<!-- Reviewable:end -->
