### PR TITLE
Make tests link to GTest::gtest_main

### DIFF
--- a/cpp/OalprLicensePlateTextDetection/test/CMakeLists.txt
+++ b/cpp/OalprLicensePlateTextDetection/test/CMakeLists.txt
@@ -42,7 +42,7 @@ if (${GTEST_FOUND})
     add_executable(OalprLicensePlateTextDetectionTest test_oalpr_text_detection.cpp)
     target_link_libraries(OalprLicensePlateTextDetectionTest
         mpfOALPRLicensePlateTextDetection mpfComponentTestUtils
-        GTest::GTest GTest::Main)
+        GTest::gtest_main)
 
     add_test(NAME OalprLicensePlateTextDetectionTest COMMAND OalprLicensePlateTextDetectionTest)
 

--- a/cpp/TesseractOCRTextDetection/test/CMakeLists.txt
+++ b/cpp/TesseractOCRTextDetection/test/CMakeLists.txt
@@ -38,7 +38,7 @@ if (${GTEST_FOUND})
 
     include_directories(..)
     add_executable(TesseractOCRTextDetectionTest test_tesseract_ocr_detection.cpp)
-    target_link_libraries(TesseractOCRTextDetectionTest mpfTesseractOCRTextDetection mpfComponentTestUtils GTest::GTest GTest::Main)
+    target_link_libraries(TesseractOCRTextDetectionTest mpfTesseractOCRTextDetection mpfComponentTestUtils GTest::gtest_main)
 
     add_test(NAME TesseractOCRTextDetectionTest COMMAND TesseractOCRTextDetectionTest)
 


### PR DESCRIPTION
**Issues:**

Fix the following error that occurs on a clean build (among others):

```
#307 [openmpf_tesseract_ocr_text_detection:openmpf-docker-master_699 build_component 6/6] RUN if [ "${RUN_TESTS,,}" == true ]; then cd $BUILD_DIR/test && ./TesseractOCRTextDetectionTest; fi
#307 1693.0 ScrollView: Waiting for server...
#307 1814.0 ScrollView: Waiting for server...
#307 1814.0 ScrollView: Waiting for server...
#307 1814.0 ScrollView: Waiting for server...
#307 1814.0 ScrollView: Waiting for server...
```

**Related PRs:**
- https://github.com/openmpf/openmpf-contrib-components/pull/83

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-components/311)
<!-- Reviewable:end -->
