### PR TITLE
Update Azure Translation's 50k char limit.

### DIFF
--- a/python/AzureTranslation/acs_translation_component/acs_translation_component.py
+++ b/python/AzureTranslation/acs_translation_component/acs_translation_component.py
@@ -433,7 +433,7 @@ class BreakSentenceClient:
 
     # ACS limits the number of characters that can be translated in a single /translate call.
     # Taken from https://docs.microsoft.com/en-us/azure/cognitive-services/translator/reference/v3-0-translate
-    TRANSLATION_MAX_CHARS = 10_000
+    TRANSLATION_MAX_CHARS = 50_000
 
     # ACS limits the number of characters that can be processed in a single /breaksentence call.
     # Taken from https://docs.microsoft.com/en-us/azure/cognitive-services/translator/reference/v3-0-break-sentence


### PR DESCRIPTION
**Issues:**

- https://github.com/openmpf/openmpf/issues/1771

So far, Azure's 50k character limit behaves as advertised - confirmed that the invisible reverse chars (i.e. `'RIGHT-TO-LEFT OVERRIDE' (U+202E)`) are also counted as part of the character length limit. 

Component tests currently indicate that such characters are properly accounted for during `len()` checks. Updating the char limit to 50k and including all characters of concern (arabic - reversed chars, invisible (U+202E), regular text) did not produce any issues and returned results from Azure. 

We can update the char limit as a baseline update for the component and add improvements for text splitting in a future `develop` PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/openmpf/openmpf-components/356)
<!-- Reviewable:end -->
